### PR TITLE
Issue/96 - Taxonomies: add support for multiples.

### DIFF
--- a/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -2525,7 +2525,7 @@ class Base_List_Table extends \WP_List_Table {
 		foreach ( $taxonomies as $tax ) {
 
 			// Skip if private
-			if ( ! $tax->public ) {
+			if ( empty( $tax->public ) ) {
 				continue;
 			}
 

--- a/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -794,7 +794,9 @@ class Base_List_Table extends \WP_List_Table {
 		$retval = array();
 
 		// Get the taxonomies
-		$taxonomies = get_object_taxonomies( $this->get_primary_post_type() );
+		$taxonomies = sugar_calendar_get_object_taxonomies(
+			$this->get_primary_post_type()
+		);
 
 		// Maybe add taxonomies to tabs array
 		if ( empty( $taxonomies ) ) {
@@ -2359,8 +2361,10 @@ class Base_List_Table extends \WP_List_Table {
 			}
 		}
 
-		// Get event terms
-		$taxos = get_object_taxonomies( $this->get_primary_post_type() );
+		// Get taxonomies
+		$taxos = sugar_calendar_get_object_taxonomies(
+			$this->get_primary_post_type()
+		);
 
 		// Maybe loop through taxonomies, and add terms to
 		if ( ! empty( $taxos ) && is_array( $taxos ) ) {
@@ -2504,7 +2508,10 @@ class Base_List_Table extends \WP_List_Table {
 		}
 
 		// Get taxonomies for this post type
-		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
+		$taxonomies = sugar_calendar_get_object_taxonomies(
+			$post_type,
+			'objects'
+		);
 
 		// Bail if no taxonomies
 		if ( empty( $taxonomies ) ) {

--- a/sugar-event-calendar/includes/admin/nav.php
+++ b/sugar-event-calendar/includes/admin/nav.php
@@ -36,23 +36,23 @@ function display() {
 
 	// Maybe add taxonomies to tabs array
 	if ( ! empty( $taxonomies ) ) {
-		foreach ( $taxonomies as $tax => $details ) {
+		foreach ( $taxonomies as $tax ) {
 
 			// Skip if private
-			if ( ! $details->public ) {
+			if ( empty( $tax->public ) ) {
 				continue;
 			}
 
 			// Skip if current user cannot manage
-			if ( ! current_user_can( $details->cap->manage_terms ) ) {
+			if ( ! current_user_can( $tax->cap->manage_terms ) ) {
 				continue;
 			}
 
 			// Add taxonomy to tabs
-			$tabs[ $tax ] = array(
-				'name' => $details->labels->menu_name,
+			$tabs[ $tax->name ] = array(
+				'name' => $tax->labels->menu_name,
 				'url'  => add_query_arg( array(
-					'taxonomy'  => $tax,
+					'taxonomy'  => $tax->name,
 					'post_type' => $post_type
 				), admin_url( 'edit-tags.php' ) )
 			);

--- a/sugar-event-calendar/includes/admin/nav.php
+++ b/sugar-event-calendar/includes/admin/nav.php
@@ -10,7 +10,7 @@ namespace Sugar_Calendar\Admin\Nav;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Get the product tabs for Events, Calendars, and more.
+ * Display the tabs for Events, Calendars, and more.
  *
  * @since 2.0.0
  */
@@ -29,7 +29,10 @@ function display() {
 	$post_type = sugar_calendar_get_event_post_type_id();
 
 	// Get the taxonomies
-	$taxonomies = get_object_taxonomies( $post_type, 'objects' );
+	$taxonomies = sugar_calendar_get_object_taxonomies(
+		$post_type,
+		'objects'
+	);
 
 	// Maybe add taxonomies to tabs array
 	if ( ! empty( $taxonomies ) ) {
@@ -225,7 +228,8 @@ function taxonomy_tabs() {
 
 	// Get taxonomies
 	$taxonomy   = sanitize_key( $taxnow );
-	$taxonomies = get_object_taxonomies( sugar_calendar_get_event_post_type_id() );
+	$post_type  = sugar_calendar_get_event_post_type_id();
+	$taxonomies = sugar_calendar_get_object_taxonomies( $post_type );
 
 	// Bail if current taxonomy is not an event taxonomy
 	if ( empty( $taxonomies ) || ! in_array( $taxonomy, $taxonomies, true ) ) {

--- a/sugar-event-calendar/includes/post/query-filters.php
+++ b/sugar-event-calendar/includes/post/query-filters.php
@@ -28,12 +28,20 @@ function sc_modify_events_archive( $query = false ) {
 		return $query;
 	}
 
-	// Primary type & tax
-	$post_type = sugar_calendar_get_event_post_type_id();
-	$tax       = sugar_calendar_get_calendar_taxonomy_id();
+	// Get post types and taxonomies
+	$pts = sugar_calendar_allowed_post_types();
+	$tax = sugar_calendar_get_object_taxonomies( $pts );
 
 	// Only proceed if an Event post type or Calendar taxonomy
-	if ( is_post_type_archive( $post_type ) || is_tax( $tax ) ) {
+	if ( is_post_type_archive( $pts ) || is_tax( $tax ) ) {
+
+		// Get the current post type
+		$post_type = $query->get( 'post_type' );
+
+		// Fallback to default post type
+		if ( empty( $post_type ) ) {
+			$post_type = sugar_calendar_get_event_post_type_id();
+		}
 
 		// Events table alias
 		$alias = 'sce';

--- a/sugar-event-calendar/includes/post/taxonomies.php
+++ b/sugar-event-calendar/includes/post/taxonomies.php
@@ -118,6 +118,58 @@ function sugar_calendar_relate_taxonomy_to_post_types() {
 }
 
 /**
+ * Get all taxonomies for all supported Event relationships.
+ *
+ * @since 2.0.19
+ *
+ * @param string|array $types
+ * @return array
+ */
+function sugar_calendar_get_object_taxonomies( $types = '', $output = 'names' ) {
+
+	// Default return value
+	$retval = array();
+
+	// Fallback types to an array of post types that support Events
+	if ( empty( $types ) ) {
+		$types = sugar_calendar_allowed_post_types();
+	}
+
+	// Bail if no post types allow Events (weird!)
+	if ( empty( $types ) ) {
+		return $retval;
+	}
+
+	// Default output to names
+	if ( ! in_array( $output, array( 'objects', 'names' ), true ) ) {
+		$output = 'names';
+	}
+
+	// Cast strings to array
+	if ( is_string( $types ) ) {
+		$types = (array) $types;
+	}
+
+	// Loop through types
+	foreach ( $types as $type ) {
+
+		// Get taxonomies for post type
+		$taxonomies = get_object_taxonomies( $type, $output );
+
+		// Skip if empty
+		if ( empty( $taxonomies ) ) {
+			continue;
+		}
+
+		// Merge
+		$retval = array_merge( $retval, $taxonomies );
+	}
+
+	// Filter & return
+	return (array) apply_filters( 'sugar_calendar_get_taxonomies', $retval );
+}
+
+/**
  * Get the color of a calendar
  *
  * @since 2.0.0

--- a/sugar-event-calendar/includes/post/taxonomies.php
+++ b/sugar-event-calendar/includes/post/taxonomies.php
@@ -30,6 +30,9 @@ function sugar_calendar_get_calendar_taxonomy_id() {
  */
 function sugar_calendar_register_calendar_taxonomy() {
 
+	// Get the taxonomy ID
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Labels
 	$labels = array(
 		'name'                       => esc_html__( 'Calendars',                           'sugar-calendar' ),
@@ -74,7 +77,7 @@ function sugar_calendar_register_calendar_taxonomy() {
 		'rewrite'               => $rewrite,
 		'capabilities'          => $caps,
 		'update_count_callback' => '_update_post_term_count',
-		'query_var'             => sugar_calendar_get_calendar_taxonomy_id(),
+		'query_var'             => $tax,
 		'show_tagcloud'         => true,
 		'hierarchical'          => true,
 		'show_in_nav_menus'     => false,
@@ -87,7 +90,7 @@ function sugar_calendar_register_calendar_taxonomy() {
 
 	// Register
 	register_taxonomy(
-		sugar_calendar_get_calendar_taxonomy_id(),
+		$tax,
 		sugar_calendar_get_event_post_type_id(),
 		$args
 	);

--- a/sugar-event-calendar/includes/themes/legacy/ajax.php
+++ b/sugar-event-calendar/includes/themes/legacy/ajax.php
@@ -27,9 +27,11 @@ function sc_load_calendar_via_ajax() {
 		return;
 	}
 
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Get calendar attributes
-	$category = ! empty( $_REQUEST[ 'sc_event_category' ] )
-		? sanitize_text_field( $_REQUEST[ 'sc_event_category' ] )
+	$category = ! empty( $_REQUEST[ $tax ] )
+		? sanitize_text_field( $_REQUEST[ $tax ] )
 		: '';
 	$type     = ! empty( $_POST[ 'type' ] )
 		? sanitize_text_field( $_POST[ 'type' ] )

--- a/sugar-event-calendar/includes/themes/legacy/calendar.php
+++ b/sugar-event-calendar/includes/themes/legacy/calendar.php
@@ -42,9 +42,11 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 		}
 	}
 
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Category
-	$category = ! empty( $_REQUEST['sc_event_category'] )
-		? sanitize_text_field( $_REQUEST['sc_event_category'] )
+	$category = ! empty( $_REQUEST[ $tax ] )
+		? sanitize_text_field( $_REQUEST[ $tax ] )
 		: $category;
 
 	// Year can be set via function parameter
@@ -78,14 +80,16 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 		12 => sc_month_num_to_name(12)
 	);
 
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Arguments for category dropdown
 	$args = apply_filters( 'sc_calendar_dropdown_categories_args', array(
-		'name'             => 'sc_event_category',
-		'id'               => 'sc_event_category',
+		'name'             => $tax,
+		'id'               => $tax,
 		'show_option_all'  => __( 'All Calendars', 'sugar-calendar' ),
 		'selected'         => $category,
 		'value_field'      => 'slug',
-		'taxonomy'         => 'sc_event_category',
+		'taxonomy'         => $tax,
 		'show_option_none' => __( 'No Calendars', 'sugar-calendar' ),
 	) );
 
@@ -144,7 +148,7 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 
 				?></select>
 
-				<label for="sc_event_category" style="display:none"><?php esc_html_e( 'Calendar', 'sugar-calendar' ); ?></label>
+				<label for="<?php echo esc_attr( $tax ); ?>" style="display:none"><?php esc_html_e( 'Calendar', 'sugar-calendar' ); ?></label>
 				<?php wp_dropdown_categories( $args ); ?>
 
 				<input type="submit" id="sc_submit" class="sc_calendar_submit" value="<?php esc_attr_e( 'Go', 'sugar-calendar' ); ?>">
@@ -202,6 +206,8 @@ function sc_calendar_next_prev( $display_month, $display_year, $size = 'large', 
 	// Formally deprecated
 	_deprecated_function( __FUNCTION__, '1.1.0', 'sc_get_next_prev' );
 
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Next
 	$next_month = $display_month + 1;
 	$next_month = $next_month > 12 ? 1 : $next_month;
@@ -223,7 +229,7 @@ function sc_calendar_next_prev( $display_month, $display_year, $size = 'large', 
 			<input name="sc_nonce" type="hidden" value="<?php echo wp_create_nonce('sc_calendar_nonce'); ?>">
 			<input type="hidden" name="action" value="sc_load_calendar">
 			<input type="hidden" name="action_2" value="prev_month">
-			<input type="hidden" name="sc_event_category" value="<?php echo is_null( $category ) ? 0 : $category; ?>">
+			<input type="hidden" name="<?php echo esc_attr( $tax ); ?>" value="<?php echo is_null( $category ) ? 0 : $category; ?>">
 			<?php if($size == 'small') { ?><input type="hidden" name="sc_calendar_size" value="small"><?php } ?>
 			<input type="hidden" name="type" value="month">
 		</form>
@@ -235,7 +241,7 @@ function sc_calendar_next_prev( $display_month, $display_year, $size = 'large', 
 			<input name="sc_nonce" type="hidden" value="<?php echo wp_create_nonce('sc_calendar_nonce') ?>">
 			<input type="hidden" name="action" value="sc_load_calendar">
 			<input type="hidden" name="action_2" value="next_month">
-			<input type="hidden" name="sc_event_category" value="<?php echo is_null( $category ) ? 0 : $category; ?>">
+			<input type="hidden" name="<?php echo esc_attr( $tax ); ?>" value="<?php echo is_null( $category ) ? 0 : $category; ?>">
 			<?php if($size == 'small') { ?><input type="hidden" name="sc_calendar_size" value="small"><?php } ?>
 			<input type="hidden" name="type" value="month">
 		</form>
@@ -255,6 +261,8 @@ function sc_calendar_next_prev( $display_month, $display_year, $size = 'large', 
  * @param string $type
  */
 function sc_get_next_prev( $display_time, $size = 'large', $category = null, $type = 'month' ) {
+
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
 
 	switch ( $type ) {
 		case 'day':
@@ -291,7 +299,7 @@ function sc_get_next_prev( $display_time, $size = 'large', $category = null, $ty
 			<input type="hidden" name="display_time" value="<?php echo esc_attr( $prev_display_time ); ?>">
 			<input type="hidden" name="type" value="<?php echo esc_attr( $prev_display_time ); ?>">
 			<input type="hidden" name="action" value="sc_load_calendar">
-			<input type="hidden" name="sc_event_category" value="<?php echo is_null( $category ) ? 0 : esc_attr( $category ); ?>">
+			<input type="hidden" name="<?php echo esc_attr( $tax ); ?>" value="<?php echo is_null( $category ) ? 0 : esc_attr( $category ); ?>">
 			<?php if ( 'small' === $size ) : ?>
 				<input type="hidden" name="sc_calendar_size" value="small">
 			<?php endif; ?>
@@ -302,7 +310,7 @@ function sc_get_next_prev( $display_time, $size = 'large', $category = null, $ty
 			<input name="sc_nonce" type="hidden" value="<?php echo wp_create_nonce('sc_calendar_nonce') ?>">
 			<input type="hidden" name="display_time" value="<?php echo esc_attr( $next_display_time ); ?>">
 			<input type="hidden" name="action" value="sc_load_calendar">
-			<input type="hidden" name="sc_event_category" value="<?php echo is_null( $category ) ? 0 : esc_attr( $category ); ?>">
+			<input type="hidden" name="<?php echo esc_attr( $tax ); ?>" value="<?php echo is_null( $category ) ? 0 : esc_attr( $category ); ?>">
 			<?php if ( 'small' === $size ) : ?>
 				<input type="hidden" name="sc_calendar_size" value="small">
 			<?php endif; ?>

--- a/sugar-event-calendar/includes/themes/legacy/event-display.php
+++ b/sugar-event-calendar/includes/themes/legacy/event-display.php
@@ -30,12 +30,8 @@ function sc_event_content_hooks( $content = '' ) {
 		return $content;
 	}
 
-	// Get post types and taxonomies
-	$pts = sugar_calendar_allowed_post_types();
-	$tax = sugar_calendar_get_object_taxonomies( $pts );
-
-	// Bail if not single event, event archive, or calendar archive
-	if ( ! ( is_singular( $pts ) || is_post_type_archive( $pts ) || is_tax( $tax ) ) ) {
+	// Bail if not doing events
+	if ( ! sc_doing_events() ) {
 		return $content;
 	}
 

--- a/sugar-event-calendar/includes/themes/legacy/event-display.php
+++ b/sugar-event-calendar/includes/themes/legacy/event-display.php
@@ -30,8 +30,12 @@ function sc_event_content_hooks( $content = '' ) {
 		return $content;
 	}
 
+	// Get IDs
+	$post_type = sugar_calendar_get_event_post_type_id();
+	$tax       = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Bail if not single event, event archive, or calendar archive
-	if ( ! ( is_singular( 'sc_event' ) || is_post_type_archive( 'sc_event' ) || is_tax( 'sc_event_category' ) ) ) {
+	if ( ! ( is_singular( $post_type ) || is_post_type_archive( $post_type ) || is_tax( $tax ) ) ) {
 		return $content;
 	}
 

--- a/sugar-event-calendar/includes/themes/legacy/event-display.php
+++ b/sugar-event-calendar/includes/themes/legacy/event-display.php
@@ -30,12 +30,12 @@ function sc_event_content_hooks( $content = '' ) {
 		return $content;
 	}
 
-	// Get IDs
-	$post_type = sugar_calendar_get_event_post_type_id();
-	$tax       = sugar_calendar_get_calendar_taxonomy_id();
+	// Get post types and taxonomies
+	$pts = sugar_calendar_allowed_post_types();
+	$tax = sugar_calendar_get_object_taxonomies( $pts );
 
 	// Bail if not single event, event archive, or calendar archive
-	if ( ! ( is_singular( $post_type ) || is_post_type_archive( $post_type ) || is_tax( $tax ) ) ) {
+	if ( ! ( is_singular( $pts ) || is_post_type_archive( $pts ) || is_tax( $tax ) ) ) {
 		return $content;
 	}
 

--- a/sugar-event-calendar/includes/themes/legacy/events-list.php
+++ b/sugar-event-calendar/includes/themes/legacy/events-list.php
@@ -80,9 +80,12 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 		);
 	}
 
+	// Get the taxonomy ID
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Maybe filter by taxonomy term
 	if ( ! empty( $category ) ) {
-		$args[ sugar_calendar_get_calendar_taxonomy_id() ] = $category;
+		$args[ $tax ] = $category;
 	}
 
 	// Query for events
@@ -132,7 +135,7 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 		}
 
 		if ( ! empty( $show['categories'] ) ) {
-			$event_categories = get_the_terms( $event_id, 'sc_event_category' );
+			$event_categories = get_the_terms( $event_id, $tax );
 
 			if ( $event_categories ) {
 				$categories = wp_list_pluck( $event_categories, 'name' );

--- a/sugar-event-calendar/includes/themes/legacy/events-list.php
+++ b/sugar-event-calendar/includes/themes/legacy/events-list.php
@@ -80,7 +80,8 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 		);
 	}
 
-	// Get the taxonomy ID
+	// Get the IDs
+	$pt  = sugar_calendar_get_event_post_type_id();
 	$tax = sugar_calendar_get_calendar_taxonomy_id();
 
 	// Maybe filter by taxonomy term
@@ -110,7 +111,7 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 		// Get the object ID and use it for the event ID (for back compat)
 		$event_id = $event->object_id;
 
-		echo '<li class="' . str_replace( 'hentry', '', implode( ' ', get_post_class( 'sc_event',$event_id ) ) ) . '">';
+		echo '<li class="' . str_replace( 'hentry', '', implode( ' ', get_post_class( $pt, $event_id ) ) ) . '">';
 
 		do_action( 'sc_before_event_list_item', $event_id );
 

--- a/sugar-event-calendar/includes/themes/legacy/functions.php
+++ b/sugar-event-calendar/includes/themes/legacy/functions.php
@@ -85,6 +85,28 @@ function sc_is_event_for_day( $event, $day = '01', $month = '01', $year = '1970'
 }
 
 /**
+ * Return if doing events, either singular, archive, or related taxonomy
+ *
+ * @since 2.0.19
+ *
+ * @return boolean
+ */
+function sc_doing_events() {
+
+	// Get post types and taxonomies
+	$pts = sugar_calendar_allowed_post_types();
+	$tax = sugar_calendar_get_object_taxonomies( $pts );
+
+	// Return true if single event, event archive, or allowed taxonomy archive
+	if ( is_singular( $pts ) || is_post_type_archive( $pts ) || is_tax( $tax ) ) {
+		return true;
+	}
+
+	// Default false
+	return false;
+}
+
+/**
  * Retrieves recurring events
  *
  * @since 2.0.0
@@ -1392,7 +1414,7 @@ function sc_update_recurring_events( $event_id = 0 ) {
 	} else {
 		$events = get_posts( array(
 			'numberposts' => - 1,
-			'post_type'   => 'sc_event',
+			'post_type'   => sugar_calendar_get_event_post_type_id(),
 			'post_status' => 'publish',
 			'fields'      => 'ids',
 			'order'       => 'asc'
@@ -1460,7 +1482,7 @@ function sc_calculate_recurring( $event_id ) {
 function sc_get_all_events( $category = null ) {
 	$args = array(
 		'numberposts' => -1,
-		'post_type'   => 'sc_event',
+		'post_type'   => sugar_calendar_get_event_post_type_id(),
 		'post_status' => 'publish',
 		'orderby'     => 'meta_value_num',
 		'fields'      => 'ids',
@@ -1576,7 +1598,7 @@ function sc_get_recurring_events( $time, $type, $category = null ) {
 	}
 
 	$args = array(
-		'post_type'      => 'sc_event',
+		'post_type'      => sugar_calendar_get_event_post_type_id(),
 		'posts_per_page' => -1,
 		'post_status'    => 'publish',
 		'fields'         => 'ids',
@@ -1674,7 +1696,7 @@ function sc_get_events_for_day( $display_day, $display_month, $display_year, $ca
 
 	$args = array(
 		'numberposts' => -1,
-		'post_type'   => 'sc_event',
+		'post_type'   => sugar_calendar_get_event_post_type_id(),
 		'post_status' => 'publish',
 		'orderby'     => 'meta_value_num',
 		'order'       => 'asc',

--- a/sugar-event-calendar/includes/themes/legacy/functions.php
+++ b/sugar-event-calendar/includes/themes/legacy/functions.php
@@ -144,12 +144,14 @@ function sc_get_event_class( $object_id = false ) {
 		return '';
 	}
 
+	$tax = sugar_calendar_get_calendar_taxonomy_id();
+
 	// Check term cache first
-	$terms = get_object_term_cache( $object_id, 'sc_event_category' );
+	$terms = get_object_term_cache( $object_id, $tax );
 
 	// No cache, so query for terms
 	if ( false === $terms ) {
-		$terms = wp_get_object_terms( $object_id, 'sc_event_category' );
+		$terms = wp_get_object_terms( $object_id, $tax );
 	}
 
 	// Bail if no terms
@@ -1466,7 +1468,8 @@ function sc_get_all_events( $category = null ) {
 	);
 
 	if ( ! is_null( $category ) ) {
-		$args[ 'sc_event_category' ] = $category;
+		$tax          = sugar_calendar_get_calendar_taxonomy_id();
+		$args[ $tax ] = $category;
 	}
 
 	$full_list = array();
@@ -1645,7 +1648,8 @@ function sc_get_recurring_events( $time, $type, $category = null ) {
 	}
 
 	if ( ! is_null( $category ) ) {
-		$args[ 'sc_event_category' ] = $category;
+		$tax          = sugar_calendar_get_calendar_taxonomy_id();
+		$args[ $tax ] = $category;
 	}
 
 	return get_posts( apply_filters( 'sc_recurring_events_query', $args ) );
@@ -1690,8 +1694,9 @@ function sc_get_events_for_day( $display_day, $display_month, $display_year, $ca
 		),
 	);
 
-	if ( !is_null( $category ) ) {
-		$args[ 'sc_event_category' ] = $category;
+	if ( ! is_null( $category ) ) {
+		$tax          = sugar_calendar_get_calendar_taxonomy_id();
+		$args[ $tax ] = $category;
 	}
 
 	$single = get_posts( apply_filters( 'sc_calendar_query_args', $args ) );

--- a/sugar-event-calendar/includes/themes/legacy/scripts.php
+++ b/sugar-event-calendar/includes/themes/legacy/scripts.php
@@ -47,7 +47,7 @@ function sc_load_front_end_scripts() {
 		||
 		sc_using_widget()
 		||
-		is_singular( 'sc_event' )
+		sc_doing_events()
 		||
 		sc_content_has_shortcodes()
 	) {

--- a/sugar-event-calendar/includes/themes/legacy/widgets.php
+++ b/sugar-event-calendar/includes/themes/legacy/widgets.php
@@ -111,6 +111,7 @@ class sc_events_widget extends WP_Widget {
 	 * @return string|void
 	 */
 	public function form( $instance ) {
+		$tax      = sugar_calendar_get_calendar_taxonomy_id();
 		$title    = isset($instance['title']) ? $instance['title'] : '';
 		$size     = isset($instance['size']) ? $instance['size'] : '';
 		$category = isset($instance['category']) ? $instance['category'] : '';
@@ -132,7 +133,7 @@ class sc_events_widget extends WP_Widget {
 			<label for="<?php echo $this->get_field_id('category'); ?>"><?php _e('Calendar:', 'sugar-calendar'); ?></label>
 			<select class="widefat <?php echo $this->get_field_name('category'); ?>" name="<?php echo $this->get_field_name('category'); ?>" id="<?php echo $this->get_field_id('category'); ?>">
 				<option value="0" <?php selected(0, $category); ?>><?php _e('All', 'sugar-calendar'); ?></option><?php
-					$terms = get_terms('sc_event_category');
+					$terms = get_terms( $tax );
 					if ($terms) {
 						foreach ($terms as $term) {
 							echo '<option value="' . $term->slug . '" ' . selected($term->slug, $category, false) . '>' . esc_html( $term->name ) . '</option>';
@@ -221,6 +222,7 @@ class sc_events_list_widget extends WP_Widget
 	 * @return string|void
 	 */
 	public function form( $instance ) {
+		$tax             = sugar_calendar_get_calendar_taxonomy_id();
 		$title           = isset($instance['title']) ? esc_attr($instance['title']) : '';
 		$display         = isset($instance['display']) ? esc_attr($instance['display']) : '';
 		$display_order   = ( 'past' === $display ) ? 'DESC' : 'ASC';
@@ -273,7 +275,7 @@ class sc_events_list_widget extends WP_Widget
 			<select class="widefat <?php echo $this->get_field_name('category'); ?>" name="<?php echo $this->get_field_name('category'); ?>" id="<?php echo $this->get_field_id('category'); ?>">
 				<option value="0" <?php selected(0, $category); ?>><?php _e('All Calendars', 'sugar-calendar'); ?></option>
 				<?php
-				$terms = get_terms('sc_event_category');
+				$terms = get_terms( $tax );
 				if (count( $terms) ) {
 					foreach ($terms as $term) {
 						echo '<option value="' . $term->slug . '" ' . selected($term->slug, $category, false) . '>' . $term->name . '</option>';
@@ -354,6 +356,7 @@ class sc_event_categories_widget extends WP_Widget {
 	 * @param array $instance
 	 */
 	public function widget( $args, $instance ) {
+		$tax           = sugar_calendar_get_calendar_taxonomy_id();
 		$before_widget = isset($args['before_widget']) ? $args['before_widget'] : '';
 		$before_title  = isset($args['before_title']) ? $args['before_title'] : '';
 		$after_title   = isset($args['after_title']) ? $args['after_title'] : '';
@@ -367,7 +370,7 @@ class sc_event_categories_widget extends WP_Widget {
 		}
 
 		do_action('sc_before_category_widget');
-		$terms = get_terms('sc_event_category');
+		$terms = get_terms( $tax );
 
 		if ( is_wp_error( $terms ) ) {
 			return;


### PR DESCRIPTION
This commit introduces two new functions (sugar_calendar_get_requested_terms() and sugar_calendar_get_object_taxonomies()) and uses them to eliminate some hardcoded assumptions about the Calendar taxonomy, mostly that it is the only one.

We replace calls to get_object_taxonomies() with the new Sugar Calendar equivalent, thus allowing for all taxonomies for all post types that support "events" to get equal treatment.

See #96 