### PR TITLE
Hides non-public taxonomies from UI

### DIFF
--- a/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-event-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -2516,6 +2516,12 @@ class Base_List_Table extends \WP_List_Table {
 
 		// Loop through taxonomies and setup the dropdowns
 		foreach ( $taxonomies as $tax ) {
+
+			// Skip if private
+			if ( ! $tax->public ) {
+				continue;
+			}
+
 			$current = $this->get_tax_term( $tax->name );
 
 			// Label for dropdown

--- a/sugar-event-calendar/includes/admin/nav.php
+++ b/sugar-event-calendar/includes/admin/nav.php
@@ -36,6 +36,11 @@ function display() {
 	if ( ! empty( $taxonomies ) ) {
 		foreach ( $taxonomies as $tax => $details ) {
 
+			// Skip if private
+			if ( ! $details->public ) {
+				continue;
+			}
+
 			// Skip if current user cannot manage
 			if ( ! current_user_can( $details->cap->manage_terms ) ) {
 				continue;


### PR DESCRIPTION
Omits non-public taxonomies from tabs and filters when viewing Calendar

Fixes #98