### PR TITLE
Issue/64 - Allow entering hours in 12 or 24 hour clock format.

### DIFF
--- a/sugar-event-calendar/includes/admin/meta-boxes.php
+++ b/sugar-event-calendar/includes/admin/meta-boxes.php
@@ -386,13 +386,17 @@ function prepare_date_time( $prefix = 'start' ) {
 		? sanitize_text_field( $_POST[ $prefix . 'time_second' ] )
 		: 0;
 
-	// Day/night
-	$am_pm = ! empty( $_POST[ $prefix . 'time_am_pm' ] )
-		? sanitize_text_field( $_POST[ $prefix . 'time_am_pm' ] )
-		: 'am';
+	// Maybe adjust for meridiem
+	if ( '12' === sugar_calendar_get_clock_type() ) {
 
-	// Maybe tweak hours
-	$hour = adjust_hour_for_meridiem( $hour, $am_pm );
+		// Day/night
+		$am_pm = ! empty( $_POST[ $prefix . 'time_am_pm' ] )
+			? sanitize_text_field( $_POST[ $prefix . 'time_am_pm' ] )
+			: 'am';
+
+		// Maybe tweak hours
+		$hour = adjust_hour_for_meridiem( $hour, $am_pm );
+	}
 
 	// Make timestamp from pieces
 	$timestamp = mktime(
@@ -738,6 +742,16 @@ function calendars( $post, $box ) {
  */
 function section_duration( $event = null ) {
 
+	// Get clock type, hours, and minutes
+	$clock   = sugar_calendar_get_clock_type();
+	$hours   = sugar_calendar_get_hours();
+	$minutes = sugar_calendar_get_minutes();
+
+	// Get the hour format based on the clock type
+	$hour_format = ( '12' === $clock )
+		? 'h'
+		: 'H';
+
 	// Setup empty Event if malformed
 	if ( ! is_object( $event ) ) {
 		$event = new Sugar_Calendar\Event();
@@ -776,7 +790,7 @@ function section_duration( $event = null ) {
 		if ( empty( $all_day ) ) {
 
 			// Hour
-			$end_hour = date( 'h', $end_date_time );
+			$end_hour = date( $hour_format, $end_date_time );
 			if ( empty( $end_hour ) ) {
 				$end_hour = '';
 			}
@@ -814,7 +828,7 @@ function section_duration( $event = null ) {
 		if ( empty( $all_day ) ) {
 
 			// Hour
-			$hour = date( 'h', $date_time );
+			$hour = date( $hour_format, $date_time );
 			if ( empty( $hour ) ) {
 				$hour = '';
 			}
@@ -870,7 +884,7 @@ function section_duration( $event = null ) {
 							'first'    => '&nbsp;',
 							'id'       => 'start_time_hour',
 							'name'     => 'start_time_hour',
-							'items'    => sugar_calendar_get_hours(),
+							'items'    => $hours,
 							'selected' => $hour
 						) ); ?>
 						<span class="sc-time-separator">:</span>
@@ -878,14 +892,17 @@ function section_duration( $event = null ) {
 							'first'    => '&nbsp;',
 							'id'       => 'start_time_minute',
 							'name'     => 'start_time_minute',
-							'items'    => sugar_calendar_get_minutes(),
+							'items'    => $minutes,
 							'selected' => $minute
-						) ); ?>
-						<select id="start_time_am_pm" name="start_time_am_pm" class="sc-select-chosen sc-time">
-							<option value="">&nbsp;</option>
-							<option value="am" <?php selected( $am_pm, 'am' ); ?>><?php esc_html_e( 'AM', 'sugar-calendar' ); ?></option>
-							<option value="pm" <?php selected( $am_pm, 'pm' ); ?>><?php esc_html_e( 'PM', 'sugar-calendar' ); ?></option>
-						</select>
+						) );
+
+						if ( '12' === $clock ) : ?>
+							<select id="start_time_am_pm" name="start_time_am_pm" class="sc-select-chosen sc-time">
+								<option value="">&nbsp;</option>
+								<option value="am" <?php selected( $am_pm, 'am' ); ?>><?php esc_html_e( 'AM', 'sugar-calendar' ); ?></option>
+								<option value="pm" <?php selected( $am_pm, 'pm' ); ?>><?php esc_html_e( 'PM', 'sugar-calendar' ); ?></option>
+							</select>
+						<?php endif; ?>
 					</div>
 				</td>
 
@@ -904,7 +921,7 @@ function section_duration( $event = null ) {
 							'first'    => '&nbsp;',
 							'id'       => 'end_time_hour',
 							'name'     => 'end_time_hour',
-							'items'    => sugar_calendar_get_hours(),
+							'items'    => $hours,
 							'selected' => $end_hour
 						) ); ?>
 						<span class="sc-time-separator">:</span>
@@ -912,14 +929,17 @@ function section_duration( $event = null ) {
 							'first'    => '&nbsp;',
 							'id'       => 'end_time_minute',
 							'name'     => 'end_time_minute',
-							'items'    => sugar_calendar_get_minutes(),
+							'items'    => $minutes,
 							'selected' => $end_minute
-						) ); ?>
-						<select id="end_time_am_pm" name="end_time_am_pm" class="sc-select-chosen sc-time">
-							<option value="">&nbsp;</option>
-							<option value="am" <?php selected( $end_am_pm, 'am' ); ?>><?php esc_html_e( 'AM', 'sugar-calendar' ); ?></option>
-							<option value="pm" <?php selected( $end_am_pm, 'pm' ); ?>><?php esc_html_e( 'PM', 'sugar-calendar' ); ?></option>
-						</select>
+						) );
+
+						if ( '12' === $clock ) : ?>
+							<select id="end_time_am_pm" name="end_time_am_pm" class="sc-select-chosen sc-time">
+								<option value="">&nbsp;</option>
+								<option value="am" <?php selected( $end_am_pm, 'am' ); ?>><?php esc_html_e( 'AM', 'sugar-calendar' ); ?></option>
+								<option value="pm" <?php selected( $end_am_pm, 'pm' ); ?>><?php esc_html_e( 'PM', 'sugar-calendar' ); ?></option>
+							</select>
+						<?php endif; ?>
 					</div>
 				</td>
 			</tr>

--- a/sugar-event-calendar/includes/common/time.php
+++ b/sugar-event-calendar/includes/common/time.php
@@ -254,38 +254,102 @@ function sugar_calendar_get_recurrence_types() {
 }
 
 /**
+ * Get the clock type, based on the user's preference and the site setting.
+ *
+ * Future versions of this may be able to guess a better default based on the
+ * timezone or locale.
+ *
+ * @since 2.0.19
+ *
+ * @return string
+ */
+function sugar_calendar_get_clock_type() {
+
+	// Get user time format preference
+	$pref = sugar_calendar_get_user_preference( 'time_format', 'g:i a' );
+
+	// Base clock type on time format preference
+	$retval = strstr( strtolower( $pref ), 'a' )
+		? '12'
+		: '24';
+
+	// Filter & return
+	return apply_filters( 'sugar_calendar_get_clock_type', $retval, $pref );
+}
+
+/**
  * Return array of hours
  *
- * @since 0.2.4
+ * @since 2.0.0
  *
  * @return array
  */
 function sugar_calendar_get_hours() {
-	return apply_filters( 'sugar_calendar_get_hours', array(
-		'01',
-		'02',
-		'03',
-		'04',
-		'05',
-		'06',
-		'07',
-		'08',
-		'09',
-		'10',
-		'11',
-		'12'
-	) );
+
+	// Get the clock type
+	$clock = sugar_calendar_get_clock_type();
+
+	// 12 hour clock
+	if ( '12' === $clock ) {
+		$retval = array(
+			'01',
+			'02',
+			'03',
+			'04',
+			'05',
+			'06',
+			'07',
+			'08',
+			'09',
+			'10',
+			'11',
+			'12'
+		);
+
+	// 24 hour clock
+	} else {
+		$retval = array(
+			'01',
+			'02',
+			'03',
+			'04',
+			'05',
+			'06',
+			'07',
+			'08',
+			'09',
+			'10',
+			'11',
+			'12',
+			'13',
+			'14',
+			'15',
+			'16',
+			'17',
+			'18',
+			'19',
+			'20',
+			'21',
+			'22',
+			'23'
+		);
+	}
+
+	// Filter & return
+	return (array) apply_filters( 'sugar_calendar_get_hours', $retval, $clock );
 }
 
 /**
  * Return array of minutes
  *
- * @since 0.2.4
+ * @since 2.0.0
  *
  * @return array
  */
 function sugar_calendar_get_minutes() {
-	return apply_filters( 'sugar_calendar_get_minutes', array(
+
+	// Filter & return
+	return (array) apply_filters( 'sugar_calendar_get_minutes', array(
 		'00',
 		'05',
 		'10',
@@ -304,7 +368,7 @@ function sugar_calendar_get_minutes() {
 /**
  * Output a select dropdown for hours & minutes
  *
- * @since 0.2.4
+ * @since 2.0.0
  *
  * @param array $args
  */


### PR DESCRIPTION
This PR introduces the `sugar_calendar_get_clock_type()` function and uses it to decide how to handle the hour fields in the meta-box.