### PR TITLE
Issue/132

### DIFF
--- a/sugar-calendar/includes/themes/legacy/functions.php
+++ b/sugar-calendar/includes/themes/legacy/functions.php
@@ -163,7 +163,7 @@ function sc_filter_events_for_day( $events = array(), $day = '01', $month = '01'
 function sc_get_event_class( $object_id = false ) {
 
 	// This function only accepts a post ID
-	if ( empty( $object_id ) || ! is_int( $object_id ) ) {
+	if ( empty( $object_id ) || ! is_numeric( $object_id ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
This commit relaxes the strict check used to validate the $object_id parameter inside of sc_get_event_class(). Some functions call this function using numeric strings, which is causing there to be no class names for events that should have them.