### PR TITLE
Issue/168 - Next/Prev/Pagination: Avoid undesirable overflows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"webpack": "4.29.6",
 		"webpack-cli": "^3.3.12",
 		"grunt-cli": "^1.3.2"
-  },
+	},
 	"scripts": {
 		"build": "cross-env NODE_ENV=production webpack",
 		"dev": "cross-env NODE_ENV=default webpack --watch",

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -3414,11 +3414,25 @@ class Base_List_Table extends \WP_List_Table {
 		// Base URLs
 		$today = $this->get_today_url();
 
+		// Today's small & large timestamps
+		$ts    = $this->today;
+		$tl    = $this->today;
+
+		// Adjust small for month
+		if ( strstr( $r['small'], 'month' ) ) {
+			$ts = strtotime( gmdate( 'Y-m-01', $ts ) );
+		}
+
+		// Adjust large for month
+		if ( strstr( $r['large'], 'month' ) ) {
+			$tl = strtotime( gmdate( 'Y-m-01', $tl ) );
+		}
+
 		// Calculate previous & next weeks & months
-		$prev_small = strtotime( "-{$r['small']}", $this->today );
-		$next_small = strtotime( "+{$r['small']}", $this->today );
-		$prev_large = strtotime( "-{$r['large']}", $this->today );
-		$next_large = strtotime( "+{$r['large']}", $this->today );
+		$prev_small = strtotime( "-{$r['small']}", $ts );
+		$next_small = strtotime( "+{$r['small']}", $ts );
+		$prev_large = strtotime( "-{$r['large']}", $tl );
+		$next_large = strtotime( "+{$r['large']}", $tl );
 
 		// Week
 		$prev_small_d = gmdate( 'j', $prev_small );

--- a/sugar-calendar/includes/languages/sugar-calendar.pot
+++ b/sugar-calendar/includes/languages/sugar-calendar.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sugar Calendar (Lite) 2.1.6\n"
 "Report-Msgid-Bugs-To: https://sugarcalendar.com\n"
-"POT-Creation-Date: 2021-01-26 02:15:00+00:00\n"
+"POT-Creation-Date: 2021-02-02 02:07:53+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -342,7 +342,7 @@ msgstr ""
 
 #: sugar-calendar/includes/admin/help.php:213
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:397
-#: sugar-calendar/includes/themes/legacy/calendar.php:139
+#: sugar-calendar/includes/themes/legacy/calendar.php:141
 msgid "Month"
 msgstr ""
 
@@ -389,7 +389,7 @@ msgid "<code>28</code> through <code>31</code>"
 msgstr ""
 
 #: sugar-calendar/includes/admin/help.php:261
-#: sugar-calendar/includes/themes/legacy/calendar.php:150
+#: sugar-calendar/includes/themes/legacy/calendar.php:152
 msgid "Year"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Previous year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3462
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3476
 #: sugar-calendar/includes/admin/settings.php:537
 #: sugar-calendar/includes/admin/settings.php:594
 msgid "Options"
@@ -971,7 +971,7 @@ msgstr ""
 #: sugar-calendar/includes/admin/menu.php:34
 #: sugar-calendar/includes/admin/menu.php:35
 #: sugar-calendar/includes/post/taxonomies.php:39
-#: sugar-calendar/includes/themes/legacy/calendar.php:161
+#: sugar-calendar/includes/themes/legacy/calendar.php:163
 msgid "Calendar"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid "Popular Calendars"
 msgstr ""
 
 #: sugar-calendar/includes/post/taxonomies.php:42
-#: sugar-calendar/includes/themes/legacy/calendar.php:99
+#: sugar-calendar/includes/themes/legacy/calendar.php:101
 #: sugar-calendar/includes/themes/legacy/widgets.php:377
 msgid "All Calendars"
 msgstr ""
@@ -1449,7 +1449,7 @@ msgid "Choose from the most used calendars"
 msgstr ""
 
 #: sugar-calendar/includes/post/taxonomies.php:53
-#: sugar-calendar/includes/themes/legacy/calendar.php:103
+#: sugar-calendar/includes/themes/legacy/calendar.php:105
 msgid "No Calendars"
 msgstr ""
 
@@ -1561,15 +1561,15 @@ msgstr ""
 msgid "Event scheduled."
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:164
+#: sugar-calendar/includes/themes/legacy/calendar.php:166
 msgid "Go"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:309
+#: sugar-calendar/includes/themes/legacy/calendar.php:312
 msgid "Previous"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:322
+#: sugar-calendar/includes/themes/legacy/calendar.php:325
 msgid "Next"
 msgstr ""
 
@@ -1589,27 +1589,27 @@ msgstr ""
 msgid "Read More"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1249
+#: sugar-calendar/includes/themes/legacy/functions.php:1248
 msgid "Starts %s then every %s until %s"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1263
+#: sugar-calendar/includes/themes/legacy/functions.php:1262
 msgid "Starts %s then every month on the %s until %s"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1277
+#: sugar-calendar/includes/themes/legacy/functions.php:1276
 msgid "Starts %s then every year on the %s of %s until %s"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1297
+#: sugar-calendar/includes/themes/legacy/functions.php:1296
 msgid "Starts %s then every %s"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1310
+#: sugar-calendar/includes/themes/legacy/functions.php:1309
 msgid "Starts %s then every month on the %s"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/functions.php:1323
+#: sugar-calendar/includes/themes/legacy/functions.php:1322
 msgid "Starts %s then every year on the %s of %s"
 msgstr ""
 
@@ -1895,12 +1895,12 @@ msgctxt "event"
 msgid "Add New"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:239
+#: sugar-calendar/includes/themes/legacy/calendar.php:241
 msgctxt "Previous month"
 msgid "Previous"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:251
+#: sugar-calendar/includes/themes/legacy/calendar.php:253
 msgctxt "Next month"
 msgid "Next"
 msgstr ""

--- a/sugar-calendar/includes/themes/legacy/calendar.php
+++ b/sugar-calendar/includes/themes/legacy/calendar.php
@@ -65,8 +65,10 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 		? absint( $month_override )
 		: gmdate( 'n', $display_time );
 
-	// Day is always derived from time (for week & 4day views)
-	$display_day = gmdate( 'j', $display_time );
+	// Day is either 1 (for month) or derived from time (for week & 4day views)
+	$display_day = ( 'month' !== $type )
+		? gmdate( 'j', $display_time )
+		: 1;
 
 	// Recalculate display time for $calendar_func below
 	$display_time = gmmktime( 0, 0, 0, $display_month, $display_day, $display_year );
@@ -300,8 +302,9 @@ function sc_get_next_prev( $display_time, $size = 'large', $category = null, $ty
 			break;
 
 		default:
-			$next_display_time = strtotime( '+1 month', $display_time );
-			$prev_display_time = strtotime( '-1 month', $display_time );
+			$first_day         = strtotime( gmdate( 'Y-m-01', $display_time ) );
+			$next_display_time = strtotime( '+1 month', $first_day );
+			$prev_display_time = strtotime( '-1 month', $first_day );
 	} ?>
 
 	<div id="sc_event_nav_wrap">

--- a/sugar-calendar/includes/themes/legacy/functions.php
+++ b/sugar-calendar/includes/themes/legacy/functions.php
@@ -34,9 +34,8 @@ function sc_get_events_for_calendar( $day = '01', $month = '01', $year = '1970',
 
 	// Boundaries
 	$view_start  = "{$year}-{$month}-01 00:00:00";
-	$month_start = strtotime( $view_start );
-	$month_end   = strtotime( '+1 month -1 second', $month_start );
-	$view_end    = gmdate( 'Y-m-d H:i:s', $month_end );
+	$month_end   = gmdate( 't', strtotime( $view_start ) );
+	$view_end    = "{$year}-{$month}-{$month_end} 00:00:00";
 	$number      = sc_get_number_of_events();
 
 	// Default arguments


### PR DESCRIPTION
This commit prevents "next month" type links & actions from skipping months when the next/prev month is shorter than the current one. It includes changes to both the admin and theme side calendars.

Fixes #168 