### PR TITLE
Issue/176 - List Tables: introduce filter_pointer_links() method

### DIFF
--- a/sugar-calendar/includes/languages/sugar-calendar.pot
+++ b/sugar-calendar/includes/languages/sugar-calendar.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sugar Calendar (Lite) 2.1.7\n"
+"Project-Id-Version: Sugar Calendar (Lite) 2.1.8\n"
 "Report-Msgid-Bugs-To: https://sugarcalendar.com\n"
-"POT-Creation-Date: 2021-02-26 20:12:19+00:00\n"
+"POT-Creation-Date: 2021-02-26 21:59:41+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"


### PR DESCRIPTION
This method encapsulates the logic necessary to internally support WordPress filters on row-actions of various object types (post, comment, user...)