### PR TITLE
Issue/182: Calendar: include the entire end day in Events query

### DIFF
--- a/sugar-calendar/includes/themes/legacy/functions.php
+++ b/sugar-calendar/includes/themes/legacy/functions.php
@@ -35,7 +35,7 @@ function sc_get_events_for_calendar( $day = '01', $month = '01', $year = '1970',
 	// Boundaries
 	$view_start  = "{$year}-{$month}-01 00:00:00";
 	$month_end   = gmdate( 't', strtotime( $view_start ) );
-	$view_end    = "{$year}-{$month}-{$month_end} 00:00:00";
+	$view_end    = "{$year}-{$month}-{$month_end} 23:59:59";
 	$number      = sc_get_number_of_events();
 
 	// Default arguments


### PR DESCRIPTION
This commit replaces the end time of "00:00:00" with "23:59:59", ensuring that Events for that day are included in the results.

Fixes a regression introduced in 7c7a0f9a9d1a41e28062b34f1f9c67cc476e5fb0.