### PR TITLE
Issue/206 - Nav: remove duplicated "wp-header-end" HR element.

### DIFF
--- a/sugar-calendar/includes/admin/nav.php
+++ b/sugar-calendar/includes/admin/nav.php
@@ -257,8 +257,7 @@ function taxonomy_tabs() {
 	// Output the tabs
 	?><div class="wrap sc-tab-wrap"><?php
 
-		display();?>
+		display(); ?>
 
-		<hr class="wp-header-end">
 	</div><?php
 }


### PR DESCRIPTION
This commit fixes a bug that was causing WordPress core JavaScript to show an extra admin-notice.

Fixes #206.