### PR TITLE
Issue/218 - Admin: Introduce Base_List_Table::get_week_for_timestamp().

### DIFF
--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -166,7 +166,7 @@ class Base_List_Table extends \WP_List_Table {
 	 *
 	 * @var int
 	 */
-	protected $today = '';
+	protected $today = 0;
 
 	/**
 	 * The time zone for the current view
@@ -803,7 +803,7 @@ class Base_List_Table extends \WP_List_Table {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return string
+	 * @return int
 	 */
 	protected function get_current_time() {
 		return sugar_calendar_get_request_time( 'timestamp', $this->timezone );
@@ -820,6 +820,19 @@ class Base_List_Table extends \WP_List_Table {
 	 */
 	protected function get_start_of_week( $start = '1' ) {
 		return (string) sugar_calendar_get_user_preference( 'sc_start_of_week', (string) $start );
+	}
+
+	/**
+	 * Get the ISO-8601 week number for a Unix timestamp
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param int $timestamp
+	 *
+	 * @return string
+	 */
+	protected function get_week_for_timestamp( $timestamp = 0 ) {
+		return gmdate( 'W', strtotime( 'this thursday', (int) $timestamp ) );
 	}
 
 	/**

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-day.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-day.php
@@ -88,7 +88,7 @@ class Day extends Base_List_Table {
 
 		// Link text
 		$string = esc_html_x( 'Week %s', 'Week number', 'sugar-calendar' );
-		$week   = gmdate( 'W', $this->today );
+		$week   = $this->get_week_for_timestamp( $this->today );
 		$text   = sprintf( $string, $week );
 
 		// Return Week & Day

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-list.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-list.php
@@ -467,7 +467,7 @@ class Basic extends Base_List_Table {
 		if ( $item->is_all_day() ) {
 			$retval = esc_html__( 'All Day', 'sugar-calendar' );
 
-			// Maybe add duration if mulitple all-day days
+			// Maybe add duration if multiple all-day days
 			if ( $item->is_multi() ) {
 				$retval .= '<br>' . $this->get_human_diff_time( $item->start, $item->end );
 			}

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-month.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-month.php
@@ -131,10 +131,10 @@ class Month extends Base_List_Table {
 		$year  = $start->format( 'Y' );
 
 		// Week for row
-		$week  = $start->format( 'W' );
+		$week  = $this->get_week_for_timestamp( $start->format( 'U' ) );
 
 		// Calculate link to week view
-		$link_to_day  = add_query_arg( array(
+		$link_to_day = add_query_arg( array(
 			'mode' => 'week',
 			'cy'   => $year,
 			'cm'   => $month,
@@ -148,7 +148,7 @@ class Month extends Base_List_Table {
 		);
 
 		// Is this the current week?
-		if ( gmdate( 'W', $this->now ) === $week ) {
+		if ( $this->get_week_for_timestamp( $this->now ) === $week ) {
 			$classes[] = 'this-week';
 		}
 

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-week.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-week.php
@@ -44,7 +44,7 @@ class Week extends Base_List_Table {
 		$days       = array_values( $this->get_week_days() );
 		$first_day  = $days[ 0 ];
 		$last_day   = $days[ count( $days ) - 1 ];
-		$week_start = ( $this->start_of_week == gmdate( 'w', $this->today ) );
+		$week_start = ( $this->start_of_week === gmdate( 'w', $this->today ) );
 
 		// Reset the week
 		$where_is_thumbkin = ( true === $week_start )
@@ -85,7 +85,7 @@ class Week extends Base_List_Table {
 
 			// Link text
 			$string = esc_html_x( 'Week %s', 'Week number', 'sugar-calendar' );
-			$week   = gmdate( 'W', $this->today );
+			$week   = $this->get_week_for_timestamp( $this->today );
 			$text   = sprintf( $string, $week );
 
 			// Setup return value

--- a/sugar-calendar/includes/languages/sugar-calendar.pot
+++ b/sugar-calendar/includes/languages/sugar-calendar.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sugar Calendar (Lite) 2.3.0\n"
 "Report-Msgid-Bugs-To: https://sugarcalendar.com\n"
-"POT-Creation-Date: 2021-07-07 19:10:55+00:00\n"
+"POT-Creation-Date: 2021-07-07 19:57:42+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -43,7 +43,7 @@ msgstr ""
 #: sugar-calendar/includes/admin/general.php:229
 #: sugar-calendar/includes/admin/help.php:34
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:359
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2973
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2986
 #: sugar-calendar/includes/admin/nav.php:22
 msgid "Events"
 msgstr ""
@@ -228,7 +228,7 @@ msgstr ""
 
 #: sugar-calendar/includes/admin/help.php:112
 #: sugar-calendar/includes/admin/help.php:574
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2478
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2491
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-list.php:468
 #: sugar-calendar/includes/admin/meta-boxes.php:1050
 #: sugar-calendar/includes/post/functions.php:132
@@ -729,99 +729,99 @@ msgstr ""
 msgid "List"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:1644
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:1657
 msgid "(No title)"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2044
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2057
 msgid "Restore"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2049
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2062
 msgid "Delete Permanently"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2357
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2367
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2370
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2380
 #: sugar-calendar/includes/admin/meta-boxes.php:112
 msgid "Details"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2358
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2371
 msgid "Password protected"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2456
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2463
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2470
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2494
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2501
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2508
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2532
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2469
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2476
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2483
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2507
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2514
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2521
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2545
 #: sugar-calendar/includes/admin/meta-boxes.php:1063
 msgid "Start"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2458
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2465
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2472
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2496
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2503
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2510
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2551
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2471
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2478
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2485
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2509
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2516
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2523
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2564
 #: sugar-calendar/includes/admin/meta-boxes.php:1126
 msgid "End"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2627
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2640
 #: sugar-calendar/includes/admin/meta-boxes/class-wp-meta-box.php:86
 #: sugar-calendar/includes/admin/meta-boxes.php:1246
 msgid "Location"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2990
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3003
 msgid "Search Events."
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2991
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3004
 #: sugar-calendar/includes/post/types.php:73
 msgid "Search events..."
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3446
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3459
 msgid "Filter by %s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3506
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3519
 msgid "Switch to this month"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3522
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3535
 msgid "Set the day"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3537
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3550
 msgid "Set the first year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3540
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3553
 #: sugar-calendar/includes/themes/legacy/event-display.php:221
 msgid "to"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3542
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3555
 msgid "Set the last year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3550
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3563
 msgid "Set the year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3577
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3590
 msgid "Empty Trash"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3614
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3627
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-day.php:115
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-list.php:553
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-month.php:320
@@ -829,23 +829,23 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3615
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3628
 msgid "Next month"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3616
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3629
 msgid "Next year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3617
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3630
 msgid "Previous month"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3618
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3631
 msgid "Previous year"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3684
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3697
 #: sugar-calendar/includes/admin/settings.php:549
 #: sugar-calendar/includes/admin/settings.php:606
 msgid "Options"
@@ -1760,42 +1760,42 @@ msgstr ""
 msgid "A calendar with a sweet disposition."
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:1372
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:1385
 msgctxt "List table: all statuses (excluding trash)"
 msgid "All <span class=\"count\">(%s)</span>"
 msgid_plural "All <span class=\"count\">(%s)</span>"
 msgstr[0] ""
 msgstr[1] ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2057
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2070
 msgctxt "verb"
 msgid "Edit"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2062
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2075
 msgctxt "verb"
 msgid "Trash"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2067
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3573
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2080
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3586
 msgctxt "verb"
 msgid "View"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2406
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2426
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2419
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2439
 msgctxt "Time Time Zone"
 msgid "%s %s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2522
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2541
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2535
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2554
 msgctxt "20:00 on Friday"
 msgid "%s on %s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2563
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2576
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-list.php:233
 msgctxt "Noun"
 msgid "Repeats"
@@ -1821,22 +1821,22 @@ msgctxt "Noun"
 msgid "Duration"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2572
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2585
 msgctxt "Weekly from December 1, 2030 until December 31, 2030"
 msgid "%s from %s until %s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2583
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2596
 msgctxt "Weekly forever, starting May 15, 1980"
 msgid "%s starting %s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2592
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:2605
 msgctxt "Weekly forever"
 msgid "%s"
 msgstr ""
 
-#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3494
+#: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:3507
 msgctxt "Verb"
 msgid "Filter"
 msgstr ""


### PR DESCRIPTION
This method leans on strtotime() internally to get the week number for "this Thursday" which is used by the ISO-8601 standard to define the week of the year.

This change is necessary to ensure that the proper week number is output to the user in admin-area calendar views.

Fixes #218.