### PR TITLE
Issue/221 - Legacy: styling improvements for all Default themes.

### DIFF
--- a/sugar-calendar/includes/languages/sugar-calendar.pot
+++ b/sugar-calendar/includes/languages/sugar-calendar.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Sugar Calendar (Lite) 2.3.0\n"
 "Report-Msgid-Bugs-To: https://sugarcalendar.com\n"
-"POT-Creation-Date: 2021-07-07 19:57:42+00:00\n"
+"POT-Creation-Date: 2021-07-08 20:23:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -342,7 +342,7 @@ msgstr ""
 
 #: sugar-calendar/includes/admin/help.php:213
 #: sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php:420
-#: sugar-calendar/includes/themes/legacy/calendar.php:141
+#: sugar-calendar/includes/themes/legacy/calendar.php:154
 msgid "Month"
 msgstr ""
 
@@ -389,7 +389,7 @@ msgid "<code>28</code> through <code>31</code>"
 msgstr ""
 
 #: sugar-calendar/includes/admin/help.php:261
-#: sugar-calendar/includes/themes/legacy/calendar.php:152
+#: sugar-calendar/includes/themes/legacy/calendar.php:165
 msgid "Year"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 #: sugar-calendar/includes/admin/menu.php:34
 #: sugar-calendar/includes/admin/menu.php:35
 #: sugar-calendar/includes/post/taxonomies.php:41
-#: sugar-calendar/includes/themes/legacy/calendar.php:163
+#: sugar-calendar/includes/themes/legacy/calendar.php:176
 msgid "Calendar"
 msgstr ""
 
@@ -1554,15 +1554,15 @@ msgstr ""
 msgid "Event scheduled."
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:166
+#: sugar-calendar/includes/themes/legacy/calendar.php:179
 msgid "Go"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:312
+#: sugar-calendar/includes/themes/legacy/calendar.php:320
 msgid "Previous"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:325
+#: sugar-calendar/includes/themes/legacy/calendar.php:333
 msgid "Next"
 msgstr ""
 
@@ -1893,12 +1893,12 @@ msgctxt "event"
 msgid "Add New"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:241
+#: sugar-calendar/includes/themes/legacy/calendar.php:249
 msgctxt "Previous month"
 msgid "Previous"
 msgstr ""
 
-#: sugar-calendar/includes/themes/legacy/calendar.php:253
+#: sugar-calendar/includes/themes/legacy/calendar.php:261
 msgctxt "Next month"
 msgid "Next"
 msgstr ""

--- a/sugar-calendar/includes/themes/legacy/calendar.php
+++ b/sugar-calendar/includes/themes/legacy/calendar.php
@@ -135,8 +135,21 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 	do_action( 'sc_before_calendar' ); ?>
 
 	<div id="sc_events_calendar_<?php echo uniqid(); ?>" class="sc_events_calendar sc_<?php echo esc_attr( $size ); ?>">
-		<div id="sc_events_calendar_head" class="sc_clearfix">
-			<form id="sc_event_select" class="sc_events_form" method="POST" action="#sc_events_calendar_<?php echo uniqid(); ?>">
+		<div id="sc_events_calendar_head" class="sc_clearfix"><?php
+
+			// Show header if not small size
+			if ( 'small' !== $size ) :
+
+				?><h2 id="sc_calendar_title"><?php
+
+					echo esc_html( $months[ $display_month ] . ' ' . $display_year );
+
+				?></h2><?php
+
+			endif;
+
+			// Output filter form
+			?><form id="sc_event_select" class="sc_events_form" method="POST" action="#sc_events_calendar_<?php echo uniqid(); ?>">
 
 				<label for="sc_month" style="display:none"><?php esc_html_e( 'Month', 'sugar-calendar' ); ?></label>
 				<select class="sc_month" name="sc_month" id="sc_month"><?php
@@ -175,13 +188,8 @@ function sc_get_events_calendar( $size = 'large', $category = null, $type = 'mon
 				<?php endif; ?>
 			</form>
 
-			<?php if ( 'small' !== $size ) : ?>
-
-				<h2 id="sc_calendar_title"><?php
-					echo esc_html( $months[ $display_month ] . ' ' . $display_year );
-				?></h2>
-
-				<?php sc_get_next_prev( $display_time, $size, $category, $type, $start_of_week );
+			<?php if ( 'small' !== $size ) :
+				sc_get_next_prev( $display_time, $size, $category, $type, $start_of_week );
 			endif; ?>
 
 		</div><!--end #sc_events_calendar_head-->

--- a/sugar-calendar/includes/themes/legacy/css/sc-events.css
+++ b/sugar-calendar/includes/themes/legacy/css/sc-events.css
@@ -14,6 +14,8 @@
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
+	line-height: 1em;
+	cursor: default;
 }
 
 #sc_calendar table {
@@ -23,16 +25,18 @@
 	float: left;
 	padding-top: 0;
 	margin-top: 0;
+	border: none;
 }
 
 #sc_calendar th {
 	width: 13.25%;
-	background: #fdfdfd;
-	border: 1px solid #ddd;
+	background: rgba(100,100,100,0.2);
+	border: 1px solid rgba(130,130,130,0.2);
 	text-align: center;
 	text-transform: capitalize;
-	padding: 3px 4px;
+	padding: 5px;
 	font-size: 15px;
+	line-height: 15px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
@@ -40,50 +44,64 @@
 
 #sc_calendar td {
 	width: 13.25%;
-	border: 1px solid #ddd;
+	border: 1px solid rgba(130,130,130,0.2);
 	font-size: 11px;
+	line-height: 11px;
 	padding: 0;
+	position: relative;
 }
 
 #sc_calendar td.calendar-day {
-	background: #fbfbfb;
+	background: rgba(255,255,255,0.1);
 	height: 70px;
 }
 
 #sc_calendar td.calendar-day-np {
-	background: #f0f0f0;
-}
-
-#sc_calendar td div.sc_day_div a {
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-	display: block;
-	border: none;
-	text-align: left;
+	background: rgba(200,200,200,0.3);
 }
 
 #sc_calendar td div.sc_day_div {
-	padding: 8px;
+	padding: 6px;
+}
+
+#sc_calendar td div.sc_day_div a {
+	overflow: hidden;
+	white-space: nowrap;
+	display: block;
+	padding: 2px 0;
+	margin: 1px 0;
+	border: none;
+	text-align: left;
+	text-decoration: none;
+	text-overflow: ellipsis;
+	font-size: 11px;
+	line-height: 13px;
+	position: relative;
+	z-index: 2;
+	cursor: pointer;
+	box-shadow: none;
 }
 
 #sc_events_calendar_head {
-	padding: 8px;
-	background: #f0f0f0;
-	border: 1px solid #ddd;
+	padding: 10px;
+	background: rgba(200,200,200,0.3);
+	border: 1px solid rgba(130,130,130,0.2);
 	border-bottom: none;
 }
 
 #sc_event_select,
 #sc_event_nav_wrap,
 #sc_events_calendar_head h2 {
-	width: 33%;
-	float: left;
 	margin: 0;
 	clear: none;
 }
 
+#sc_event_select {
+	float: left;
+}
+
 #sc_event_nav_wrap {
+	float: right;
 	text-align: right;
 }
 
@@ -93,9 +111,11 @@
 }
 
 #sc_events_calendar_head h2 {
+	display: block;
+	margin-bottom: 10px;
 	text-align: center;
-	line-height: 26px;
 	font-size: 26px;
+	line-height: 26px;
 }
 
 #sc_events_calendar_head h2:before,
@@ -104,23 +124,41 @@
 }
 
 #sc_events_calendar_head select {
+	padding: 5px 15px 5px 5px;
 	font-size: 13px;
-	max-height: 30px;
+	line-height: 13px;
 	width: auto;
+	max-height: calc( 1.5em + 10px );
 	max-width: 33%;
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+	background-position: right 10% top 70%;
 }
 
 #sc_events_calendar_head input {
 	font-size: 13px;
+	line-height: 13px;
 	padding: 5px 10px;
+	vertical-align: initial;
 }
 
 #sc_events_calendar select,
 #sc_events_calendar input {
 	margin: 0 5px 0 0;
+	cursor: pointer;
+}
+
+#sc_calendar td div.day-number {
+	float: none;
+	position: absolute;
+	right: 2px;
+	top: 2px;
+	padding: 0;
+	margin: 0;
+	z-index: 1;
+	cursor: default;
+	color: rgba(150,150,150,0.8);
 }
 
 .sc_small #sc_event_nav_wrap {
@@ -148,16 +186,10 @@
 	text-align: left;
 }
 
-#sc_calendar td div.day-number {
-	float: right;
-	margin: -6px -4px 0 0;
-}
-
-.sc_small #sc_calendar td div.day-number {
-	float: none;
-	text-align: right;
-	padding: 0;
-	margin: -3px 1px 0 0;
+.sc_small #sc_calendar td div.sc_day_div a {
+	text-align: center;
+	font-size: 25px;
+	line-height: 20px;
 }
 
 .sc_event_details {
@@ -211,7 +243,6 @@
 	#content .sc-table tr td {
 		display: block;
 		text-align: left;
-		padding-left: 50%;
 		width: auto;
 	}
 
@@ -229,16 +260,7 @@
 
 	#sc_calendar td.calendar-day {
 		height: auto;
-		overflow: hidden;
-	}
-
-	#sc_calendar td div.day-number {
-		float: left;
-		margin: 0 5px 5px 0;
-	}
-
-	#sc-calendar .sc-table .sc_day_div {
-		overflow: hidden;
+		min-height: 70px;
 	}
 
 	#sc_events_calendar_head h2 {

--- a/sugar-calendar/includes/themes/legacy/functions.php
+++ b/sugar-calendar/includes/themes/legacy/functions.php
@@ -224,7 +224,7 @@ function sc_get_event_calendar_links( $events = array(), $size = 'small' ) {
 			// Big or small links
 			$link  = ( $size === 'small' )
 				? '<a href="' . esc_url( $url ) . '" class="' . esc_attr( $class ) . '" ' . $style . ' title="' . esc_attr( strip_tags( $title ) ) . '">&bull;</a>'
-				: '<a href="' . esc_url( $url ) . '" class="' . esc_attr( $class ) . '" ' . $style . '>' . esc_html( $title ) . '</a><br/>';
+				: '<a href="' . esc_url( $url ) . '" class="' . esc_attr( $class ) . '" ' . $style . '>' . esc_html( $title ) . '</a>';
 
 			// Add to links array
 			$links[] = apply_filters( 'sc_event_calendar_link', $link, $id, $size );


### PR DESCRIPTION
This change swaps out colors for RGBA, allowing output to work with both light & dark themes.

It also rearranges some HTML elements to make them easier to style and degrade gracefully when themes do weird things. Specifically, it moves the H2 ahead of the form & pagination, allowing it to hover above both while also giving all inputs more room to work with.

Several related improvements are being made to calendar styling at the same time, specific to links, fonts, padding, margin, and hovers, allowing for Sugar Calendar to be a bit more strict about its output without worrying about themes overloading it unintentionally.