### PR TITLE
Issue/230 - Legacy: swap the parameter order in an implode() usage.

### DIFF
--- a/sugar-calendar/includes/themes/legacy/events-list.php
+++ b/sugar-calendar/includes/themes/legacy/events-list.php
@@ -197,7 +197,7 @@ function sc_get_events_list( $display = 'upcoming', $category = null, $number = 
 
 			if ( $event_categories ) {
 				$categories = wp_list_pluck( $event_categories, 'name' );
-				echo '<span class="sc_event_categories">' . implode( $categories, ', ' ) . '</span>';
+				echo '<span class="sc_event_categories">' . implode( ', ', $categories ) . '</span>';
 			}
 		}
 


### PR DESCRIPTION
This commit fixes a notice (and warning) in some newer versions of PHP.

Props @joelyoder. Fixes #230.